### PR TITLE
Always store temperature in Celsius regardless of locale

### DIFF
--- a/src/carconnectivity_plugins/database/agents/charging_agent.py
+++ b/src/carconnectivity_plugins/database/agents/charging_agent.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import DatabaseError, IntegrityError
 from sqlalchemy.orm.exc import ObjectDeletedError
 
 from carconnectivity.observable import Observable
+from carconnectivity.units import Temperature
 from carconnectivity.vehicle import ElectricVehicle
 from carconnectivity.charging import Charging
 from carconnectivity.charging_connector import ChargingConnector
@@ -799,7 +800,7 @@ class ChargingAgent(BaseAgent):
     def __on_battery_temperature_change(self, element: TemperatureAttribute, flags: Observable.ObserverEvent) -> None:
         del flags
         if element.enabled:
-            converted_value: Optional[float] = element.in_locale(locale=self.database_plugin.locale)[0]
+            converted_value: Optional[float] = element.temperature_in(Temperature.C)
             with self.last_battery_temperature_lock:
                 with self.session_factory() as session:
                     self.vehicle = session.merge(self.vehicle)

--- a/src/carconnectivity_plugins/database/agents/state_agent.py
+++ b/src/carconnectivity_plugins/database/agents/state_agent.py
@@ -10,6 +10,7 @@ from sqlalchemy.exc import DatabaseError, IntegrityError
 from sqlalchemy.orm.exc import ObjectDeletedError
 
 from carconnectivity.observable import Observable
+from carconnectivity.units import Temperature
 from carconnectivity.utils.timeout_lock import TimeoutLock
 
 from carconnectivity_plugins.database.agents.base_agent import BaseAgent
@@ -198,7 +199,7 @@ class StateAgent(BaseAgent):
     def __on_outside_temperature_change(self, element: TemperatureAttribute, flags: Observable.ObserverEvent) -> None:
         del flags
         if element.enabled:
-            converted_value: Optional[float] = element.in_locale(locale=self.database_plugin.locale)[0]
+            converted_value: Optional[float] = element.temperature_in(Temperature.C)
             with self.last_outside_temperature_lock:
                 with self.session_factory() as session:
                     self.vehicle = session.merge(self.vehicle)

--- a/src/carconnectivity_plugins/database/plugin.py
+++ b/src/carconnectivity_plugins/database/plugin.py
@@ -60,7 +60,7 @@ class Plugin(BasePlugin):  # pylint: disable=too-many-instance-attributes
             self.active_config['locale'] = config['locale']
             try:
                 locale.setlocale(locale.LC_ALL, self.active_config['locale'])
-                if self.active_config['time_format'] is None or self.active_config['time_format'] == '':
+                if 'time_format' not in self.active_config or self.active_config['time_format'] is None or self.active_config['time_format'] == '':
                     self.active_config['time_format'] = locale.nl_langinfo(locale.D_T_FMT)
             except locale.Error as err:
                 LOG.warning('Invalid locale specified in config ("locale" must be a valid locale): %s', err)


### PR DESCRIPTION
Battery and outside temperatures were stored via in_locale(), which converts to Fahrenheit for en_US and similar locales. The Grafana dashboards hardcode the unit as Celsius, causing values like 4.5°C to be displayed as 40.1°C (the Fahrenheit equivalent).

Switch to temperature_in(Temperature.C) so the DB always contains Celsius values matching what the Grafana dashboards expect.